### PR TITLE
Fix typo

### DIFF
--- a/mattermost.py
+++ b/mattermost.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
 	message = "### "+subject + "\n\n"+sys.argv[3]
 
 	# Let's highlight every connected people if the level is serious
-	hightlight = False
+	highlight = False
 	for level in LEVELS:
 		if level in message:
 			highlight = True


### PR DESCRIPTION
The following error occurs due to this typo:

``` sh
$ python mattermost.py '#alerts' PROBLEM 'Oh no! Something is wrong!'
Traceback (most recent call last):
  File "mattermost.py", line 49, in <module>
    send_to_mattermost(URL, channel, message, username=USERNAME, color=color, icon=ICON, highlight=highlight)
NameError: name 'highlight' is not defined
```

Thank you for creating such a convenience script!